### PR TITLE
Allow user to configure httpHost and countryCode manually

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -68,6 +68,18 @@
         "type": "boolean",
         "description": "If true, the plugin will remove all accessories and not load the plugin on restart."
       },
+      "httpHost": {
+        "title": "HTTP Host",
+        "type": "string",
+        "description": "Override the default eWeLink HTTP API host, useful if you need to force a specific region/host.",
+        "placeholder": "eu-apia.coolkit.cc"
+      },
+      "countryCode": {
+        "title": "Country code",
+        "type": "string",
+        "description": "Override the default country code sent for login, may help with auth issues for users in other regions.",
+        "placeholder": "+44"
+      },
       "singleDevices": {
         "title": "Single Channel Devices",
         "description": "Applies to single-channel switch, light switch and Slampher devices.",
@@ -677,7 +689,9 @@
         "mode",
         "disableDeviceLogging",
         "debug",
-        "disablePlugin"
+        "disablePlugin",
+        "httpHost",
+        "countryCode"
       ]
     },
     {

--- a/lib/connection/http.js
+++ b/lib/connection/http.js
@@ -22,14 +22,15 @@ module.exports = class connectionHTTP {
     this.crypto = platform.crypto
 
     // Try a default http host which will be changed for other regions automatically
-    this.httpHost = 'eu-apia.coolkit.cc'
+    this.httpHost = platform.config.httpHost || 'eu-apia.coolkit.cc'
+    this.countryCode = platform.config.countryCode || '+44'
   }
 
   async login () {
     try {
       // Used to log the user in and obtain the user api key and token
       const data = {
-        countryCode: '+44',
+        countryCode: this.countryCode,
         password: this.password
       }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -415,6 +415,16 @@ class eWeLinkPlatform {
           }
           this.config.username = val.replace(/[\s]+/g, '')
           break
+        case 'httpHost':
+          if (typeof val === 'string' && val != '') {
+            this.config.httpHost = val
+          }
+          break
+        case 'countryCode':
+          if (typeof val === 'string' && val != '') {
+            this.config.countryCode = val
+          }
+          break
         default:
           logRemove(key)
           break


### PR DESCRIPTION
Fixes #248. Allows users in different regions to self-address login errors where the auto-region switching doesn't seem to handle due to the ewelink API returning an unexpected status code.

```
{
  "error": 10003,
  "msg": "user does not exists",
  "data": {}
}
```