### PR TITLE
[Fan] Change Rotation Speed from percentage to levels

### DIFF
--- a/lib/device/fan.js
+++ b/lib/device/fan.js
@@ -52,7 +52,12 @@ export default class {
     // Add the set handler to the fan rotation speed characteristic
     this.service
       .getCharacteristic(this.hapChar.RotationSpeed)
-      .setProps({ minStep: 33 })
+      .setProps({
+        maxValue: 3,
+        minStep: 1,
+        minValue: 0,
+        unit: 'unitless', // This is actually from HAP for Bluetooth LE Specification, but fits
+      })
       .onSet(async (value) => this.internalSpeedUpdate(value));
 
     // Check to see if the user has hidden the light channel
@@ -77,9 +82,9 @@ export default class {
 
     // Conversion object eWeLink mode to text label
     this.speed2label = {
-      33: 'low',
-      66: 'medium',
-      99: 'high',
+      1: 'low',
+      2: 'medium',
+      3: 'high',
     };
 
     // Add the get handlers only if the user hasn't disabled the disableNoResponse setting
@@ -130,11 +135,11 @@ export default class {
       });
       if (newState === 'on') {
         params.switches.push({
-          switch: this.cacheSpeed === 66 ? 'on' : 'off',
+          switch: this.cacheSpeed === 2 ? 'on' : 'off',
           outlet: 2,
         });
         params.switches.push({
-          switch: this.cacheSpeed === 99 ? 'on' : 'off',
+          switch: this.cacheSpeed === 3 ? 'on' : 'off',
           outlet: 3,
         });
       }
@@ -166,28 +171,25 @@ export default class {
       };
       const newState = value >= 1 ? 'on' : 'off';
       let newSpeed;
-      if (value === 0) {
+
+      if (value < 0 || value > 3) {
         newSpeed = 0;
-      } else if (value <= 33) {
-        newSpeed = 33;
-      } else if (value <= 66) {
-        newSpeed = 66;
       } else {
-        newSpeed = 99;
+        newSpeed = value;
       }
       if (newSpeed === this.cacheSpeed) {
         return;
       }
       params.switches.push({
-        switch: newState === 'on' && newSpeed >= 33 ? 'on' : 'off',
+        switch: newState === 'on' && newSpeed >= 1 ? 'on' : 'off',
         outlet: 1,
       });
       params.switches.push({
-        switch: newState === 'on' && newSpeed === 66 ? 'on' : 'off',
+        switch: newState === 'on' && newSpeed === 2 ? 'on' : 'off',
         outlet: 2,
       });
       params.switches.push({
-        switch: newState === 'on' && newSpeed === 99 ? 'on' : 'off',
+        switch: newState === 'on' && newSpeed === 3 ? 'on' : 'off',
         outlet: 3,
       });
       await this.platform.sendDeviceUpdate(this.accessory, params);
@@ -281,13 +283,13 @@ export default class {
       let speed;
       switch (params.switches[2].switch + params.switches[3].switch) {
         case 'onoff':
-          speed = 66;
+          speed = 2;
           break;
         case 'offon':
-          speed = 99;
+          speed = 3;
           break;
         default:
-          speed = 33;
+          speed = 1;
           break;
       }
       if (speed !== this.cacheSpeed && this.cacheState === 'on') {
@@ -320,9 +322,9 @@ export default class {
     const speed = this.service.getCharacteristic(this.hapChar.RotationSpeed).value;
     if (speed === 0) {
       speedLabel = 'off';
-    } else if (speed <= 33) {
+    } else if (speed <= 1) {
       speedLabel = 'low';
-    } else if (speed <= 66) {
+    } else if (speed <= 2) {
       speedLabel = 'medium';
     } else {
       speedLabel = 'high';


### PR DESCRIPTION
This PR changes units for Rotation Speed of a Fan from `%` to `speed levels`.
Sonoff fans have only 3 speed settings presented as Roman numerals on the remote (`I`, `II`, `III`).
Original implementation presented these levels as `33%`, `66%` and `99%` in HAP.
Changing them to `1`, `2` and `3` seems more intuitive and inline with original sonoff design

---

<img width="342" alt="fan_settings" src="https://github.com/bwp91/homebridge-ewelink/assets/5534215/2766f082-76c0-46cf-80a3-cd245762ec47">

--- 

<img width="336" alt="fan_badge" src="https://github.com/bwp91/homebridge-ewelink/assets/5534215/291d782f-a381-4c1c-bc95-9e1335f41faf">

