### PR TITLE
fix(garage-one): send single-outlet payload on switchSCM devices

### DIFF
--- a/lib/device/simulation/garage-one.js
+++ b/lib/device/simulation/garage-one.js
@@ -205,21 +205,33 @@ export default class {
       await sleep(delay)
       this.service.updateCharacteristic(this.hapChar.TargetDoorState, newPos)
       this.service.updateCharacteristic(this.hapChar.CurrentDoorState, newPos + 2)
+      // SCM (single-channel multi-format) devices use the switches[] array
+      // but only expose outlet 0. True dual-channel garage controllers
+      // (e.g. DUALR3) use separate outlets for open/close relay action.
+      const isScm = platformConsts.devices.switchSCM.includes(this.accessory.context.eweUIID)
+        || platformConsts.devices.switchSCMPower.includes(this.accessory.context.eweUIID)
+
       switch (this.setup) {
         case 'switchSingle':
           params.switch = 'on'
           break
         case 'switchMulti':
-          params.switches = [
-            {
-              switch: newPos === 0 ? 'on' : 'off',
-              outlet: 0,
-            },
-            {
-              switch: newPos === 1 ? 'on' : 'off',
-              outlet: 1,
-            },
-          ]
+          if (isScm) {
+            // SCM device: send a single momentary pulse on outlet 0
+            params.switches = [{ switch: 'on', outlet: 0 }]
+          } else {
+            // Dual-channel device with separate open/close relays
+            params.switches = [
+              {
+                switch: newPos === 0 ? 'on' : 'off',
+                outlet: 0,
+              },
+              {
+                switch: newPos === 1 ? 'on' : 'off',
+                outlet: 1,
+              },
+            ]
+          }
           break
         default:
           return


### PR DESCRIPTION
## Summary

Fixes the silent "close" command failure on SCM single-channel devices used as garage door simulation.

## Problem

`garage-one.js` maps `switchSCM` devices to `setup = 'switchMulti'`, which then generates a dual-outlet payload meant for true dual-channel garage controllers (e.g. DUALR3 with separate open/close relays):

```js
params.switches = [
  { switch: newPos === 0 ? 'on' : 'off', outlet: 0 },
  { switch: newPos === 1 ? 'on' : 'off', outlet: 1 },
]
```

But `switchSCM` devices (UIID 77, 78, 81, 107, 112, 138, 160, 191, 209, 264) only have **outlet 0** — they just use the `switches[]` array format for a single channel.

### Observed behaviour on MINI-D (UIID 138)

- **Open** command: payload `{outlet:0 on, outlet:1 off}` → device fires pulse on outlet 0 ✓ (outlet 1 silently ignored).
- **Close** command: payload `{outlet:0 off, outlet:1 on}` → device sees outlet 0 already off (post-inching auto-off) → **no physical action**. Outlet 1 doesn't exist. Command silently dropped.

Result: garage door opens fine, but closing always requires a second attempt.

## Fix

Detect SCM devices in `garage-one.js` and send a single momentary pulse on outlet 0, matching the payload that `switch-single-inched.js` already uses for the same device class.

## Testing

Verified locally with a SONOFF MINI-D (UIID 138) configured as `Show As: Garage Door` with a DW2 contact sensor. Before the patch: every close command was a no-op, required a second tap. After the patch: open and close both work reliably on first attempt.

## Related

Part of #769. Other related fixes will follow in separate PRs.