### PR TITLE
fix(ws): do not retry sendUpdate on timeout

### DIFF
--- a/lib/connection/ws.js
+++ b/lib/connection/ws.js
@@ -368,13 +368,11 @@ export default class {
             throw new Error(`${this.lang.wsUnkRes} [${res.error}]`)
         }
       } catch (err) {
-        // Retry up to 3 times on timeout errors only
-        const errMsg = parseError(err)
-        if (retries < 3 && (errMsg.includes('504') || errMsg.includes('timeout') || errMsg.includes('Timeout'))) {
-          await sleep(1000)
-          return this.sendUpdate(json, retries + 1)
-        }
-        throw new Error(errMsg)
+        // Do not retry on timeout: the original command may have already been
+        // applied by the device but the cloud failed to deliver a formal ACK.
+        // Retrying non-idempotent writes (e.g. inching/momentary actuators)
+        // produces additional physical pulses, causing actuators to bounce.
+        throw new Error(parseError(err))
       }
     } else {
       // The web socket isn't currently open so log this


### PR DESCRIPTION
## Summary

Removes the automatic retry on timeout in `sendUpdate`, which is unsafe for non-idempotent writes and causes physical actuators to bounce on inching/momentary devices.

## Problem

`lib/connection/ws.js` retries up to 3 times when the error message contains `504`, `timeout`, or `Timeout`:

```js
if (retries < 3 && (errMsg.includes('504') || errMsg.includes('timeout') || errMsg.includes('Timeout'))) {
  await sleep(1000)
  return this.sendUpdate(json, retries + 1)
}
```

This is unsafe because:

1. **The plugin cannot know whether the original command was applied.** A timeout on the cloud side does not imply the device didn't receive and execute the command — only that the formal ACK didn't arrive in time.

2. **Writes are not idempotent on all device types.** For lights or regular switches, replaying `{switch: 'on'}` is at worst a no-op. But for **inching/momentary devices** (MINI-D, MINI-R3, garage triggers, etc.) the device fires a physical pulse on every command. Each retry therefore generates an additional pulse: an opening shutter receives a second pulse mid-travel, reverses, then a third pulse, then a fourth — bouncing uncontrollably.

3. **The pattern matches false positives.** Strings like `"WebSocket request was rejected by timeout (20000 ms)"` (from the `promise-controller` used by `websocket-as-promised`) match the `'timeout'` substring even when the underlying command was successfully delivered, just not acknowledged in the expected format.

### Observed behaviour

Tested on a SONOFF MINI-D (UIID 138) with inching configured at device level (0.5s pulse, auto-off). The same bouncing behaviour was reproduced in both:

- **`Show As: Switch (Default)` + Status By Inching**: each HomeKit tap produced 2-4 physical pulses ~20s apart.
- **`Show As: Garage Door`**: same pattern — shutter opens, closes by itself ~20s later, opens again ~20s after.

In both modes the issue is independent of the device-handler logic: the duplicated pulses originate purely from `sendUpdate` retrying the same payload on cloud timeout.

Retries are silent in normal logs. Added a `log.warn` before the `sleep(1000)` to confirm:

```
WS SEND      seq=… payload={switches:[{switch:"on",outlet:0}]}
[…20s later…]
*** RETRY *** attempt 1 for 10027a108f after error: WebSocket request was rejected by timeout (20000 ms)
[device receives a second physical pulse and reverses direction]
*** RETRY *** attempt 2 …
```

## Fix

Remove the retry block. Cloud failures are now surfaced to the device handler immediately, which can update HomeKit accordingly (e.g. via `deviceUpdateError`).

If a more sophisticated approach is desired in the future, retry could be made opt-in per UIID via a new array in `constants.js` (similar to `skipUpdateRequest`), populated only with devices known to be idempotent and safe to retry. But the current blanket retry is actively harmful for a non-trivial subset of devices and should not stay on by default.

## Testing

Verified locally with a SONOFF MINI-D (UIID 138) in both `Show As: Switch (Default)` and `Show As: Garage Door` modes. Before the patch: each command produced 2-4 physical pulses spaced ~20s apart, causing the actuator to bounce. After the patch: exactly one pulse per command in both modes.

## Related

Part of #769. Companion PR #774 (`garage-one` SCM payload). A third PR for the underlying cloud-ACK timeout (which is what was triggering this retry in the first place) will follow.