### PR TITLE
fix(ws): use fire-and-forget for action:update commands

### DIFF
--- a/lib/connection/ws.js
+++ b/lib/connection/ws.js
@@ -322,7 +322,7 @@ export default class {
     }
   }
 
-  async sendUpdate(json, retries = 0) {
+  async sendUpdate(json) {
     // Generate the payload to send
     const toSend = {
       ...json,
@@ -344,29 +344,17 @@ export default class {
       try {
         // Generate the sequence that will be attached to the message
         const sequence = Math.floor(new Date()).toString()
+        toSend.sequence = sequence
 
-        // Send the request to eWeLink
-        const res = await this.wsClient.sendRequest(toSend, {
-          requestId: sequence,
-        })
+        // Fire-and-forget: the eWeLink cloud no longer echoes back the client
+        // sequence on 'action:update' responses (it returns a server-generated
+        // sequence instead), so wsp's request/response correlation never
+        // resolves and every command times out at the wsp level (20s).
+        // The device executes the command correctly; state changes arrive as
+        // separate broadcast 'update' messages handled by the receive listener.
+        this.wsClient.send(JSON.stringify(toSend))
 
-        // Parse the response and see if any error has been reported back
-        res.error = hasProperty(res, 'error') ? res.error : -1
-
-        // Check if and which error has been reported back
-        switch (res.error) {
-          case 0:
-            // No error is always what is wanted
-            if (res.config && res.config.hundredDaysKwhData) {
-              return res.config.hundredDaysKwhData
-            }
-            return true
-          case 504:
-            throw new Error(`${this.lang.wsReqTimeout} [504]`)
-          default:
-            // An error has occurred
-            throw new Error(`${this.lang.wsUnkRes} [${res.error}]`)
-        }
+        return true
       } catch (err) {
         // Do not retry on timeout: the original command may have already been
         // applied by the device but the cloud failed to deliver a formal ACK.


### PR DESCRIPTION
## Summary

`sendUpdate` is changed from `wsClient.sendRequest()` (request/response correlation via `sequence`) to a raw `wsClient.send()` (fire-and-forget). This is the root-cause fix for the systematic 10s/20s timeouts seen on every cloud-mode command, which in turn triggered the retry-on-timeout bug now addressed in #775.

## Problem

The eWeLink cloud no longer echoes back the client-provided `sequence` on `action: update` responses. It returns a **server-generated `sequence`** instead. Since [`websocket-as-promised`](https://github.com/vitalets/websocket-as-promised) matches each request to its response via `extractRequestId(data) => data.sequence`, the promise returned by `wsClient.sendRequest()` never resolves — it always times out at the wsp `timeout: 20000` level, even though the device executed the command correctly.

### Evidence

Verified by patching `unpackMessage` and `extractRequestId` locally to log every raw incoming frame:

```
*** WS SEND *** seq=1779924561777 payload={…deviceid:"1000a4837b","params":{"switch":"on"},"action":"update"…}
*** WS RECV *** {"error":0,"deviceid":"1000a4837b","apikey":"…","sequence":"1779924571781","params":{…,"switch":"on",…}}
*** WS RECV PARSED *** sequence="1779924571781" type=string keys=error,deviceid,apikey,sequence,params
*** WS EXTRACT REQID *** sequence="1779924571781" type=string
[Task timed out after 10000ms — p-queue]
*** WS FAIL *** seq=1779924561777 err=WebSocket request was rejected by timeout (20000 ms)
```

- Outbound sequence: `1779924561777`
- Inbound sequence: `1779924571781` (10004 ms later — looks like `Date.now()` at response generation, not an echo of the client value)

Note that `userOnline` login responses **do** still echo back the client sequence correctly (verified in the same session). The broken behaviour is specific to `action: update`. wsp is therefore left in place for the login path.

This affects **every** device controlled via cloud, regardless of UIID or showAs setting. LAN-mode users would not notice it because their commands don't go through `sendUpdate` at all.

## Fix

Replace `wsClient.sendRequest()` with a raw `wsClient.send(JSON.stringify(toSend))` and return `true` immediately. The sequence is still attached to the payload (the cloud may reject it otherwise), but is no longer used for response correlation.

Functional behaviour end-to-end is preserved because:

- The device receives and executes the command (the cloud forwards it regardless of how we wait for the ACK).
- State changes are reported asynchronously as `action: update` broadcast messages from the cloud, which are already handled by the existing `onUnpackedMessage` listener and dispatched to the device handlers via the `emitter.emit('update', ...)` path.
- Cloud-side errors (e.g. device offline) arrive as similar broadcast messages with `error` set, also already handled.

## Backward compatibility note

The original `sendUpdate` could return `res.config.hundredDaysKwhData` for devices with power monitoring (extracted from the now-broken response). With fire-and-forget, that data is no longer captured at this call site. To my knowledge nothing currently depends on this return value (callers in `platform.js` either ignore the return or only check for thrown errors), and the same `hundredDaysKwhData` should still arrive via the regular broadcast update path. Worth a quick check by a maintainer familiar with the power-monitoring devices, but I believe this is a non-issue.

## Possible follow-up

As briefly discussed with @bwp91, with this change `websocket-as-promised` is only used for `userOnline` login. A future PR could drop the `wsp` dependency entirely and replace the wrapper with raw `ws` plus a one-shot `onMessage` listener for the login response, simplifying the dependency tree. Left out of this PR to keep it focused on the bug fix.

## Testing

Verified locally with a SONOFF MINI-D (UIID 138) and a SONOFF MINI (UIID 1) in cloud mode:

- **Before:** every command produced a `Task timed out after 10000ms` log line; in combination with the retry loop (#775), commands turned into 2-4 physical pulses.
- **After:** commands complete cleanly, no timeouts in the log, single pulse per command, HomeKit state updates correctly via the broadcast path.

## Related

Part of #769. Companion PRs: #774 (`garage-one` SCM payload) and #775 (remove unsafe retry on timeout).